### PR TITLE
Remove the PIP_PRE environment variable

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,6 @@ pipeline {
 
     environment {
         PIP_INDEX_URL = 'https://artifacts.internal.inmanta.com/inmanta/dev'
-        PIP_PRE = 'true'
     }
 
     options {


### PR DESCRIPTION
# Description

This PR removes the `PIP_PRE` environment variable from the Jenkinsfile that runs the tests. If we keep it in, the `pip`, `poetry` and `devpi-client` packages are installed from a development release which is not the intention. This change doesn't have an impact on the `poetry install` command, since it doesn't take into account the `PIP_PRE` environment variable.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [ ] ~~Changelog entry~~
- [ ] ~~Type annotations are present~~
- [ ] ~~Code is clear and sufficiently documented~~
- [ ] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [ ] ~~Correct, in line with design~~
- [ ] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
