### PR TITLE
Quick fix to support having implements using parents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.2
+
+ - Add support for `implements using parents`
+
 ## 0.0.1
 
  - First implementation of the module factory.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "inmanta-module-factory"
-version = "0.0.1"
+version = "0.0.2"
 description = "Library for building inmanta modules with python code"
 authors = ["Inmanta <code@inmanta.com>"]
 license = "Apache-2.0"

--- a/src/inmanta_module_factory/inmanta/implement.py
+++ b/src/inmanta_module_factory/inmanta/implement.py
@@ -31,6 +31,7 @@ class Implement(ModuleElement):
         entity: Entity,
         condition: Optional[str] = None,
         description: Optional[str] = None,
+        using_parents: bool = False,
     ) -> None:
         """
         An implement statement
@@ -44,6 +45,7 @@ class Implement(ModuleElement):
         self.implementation = implementation
         self.entity = entity
         self.condition = condition
+        self.using_parents = using_parents
 
     def _ordering_key(self) -> str:
         return f"{chr(255)}.implement.{self.entity.full_path_string}.{self.implementation.full_path_string}"
@@ -87,6 +89,9 @@ class Implement(ModuleElement):
         if self.path_string != self.implementation.path_string:
             # Implementation is in a different file
             implementation_path = self.implementation.full_path_string
+
+        if self.using_parents:
+            implementation_path += ", parents"
 
         condition = ""
         if self.condition:


### PR DESCRIPTION
# Description

Quick fix to support having implements using parents

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] ~~attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )


