### PR TITLE
Issue/101 relation in index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v 1.0.0
 
+ - Renaming `arity` to `cardinality` in relations
  - Add support for relations in index (breaking change) (#101)
  - Extend list of inmanta reserved keywords
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-# v 0.0.3 (?)
+# v 1.0.0
 
+ - Add support for relations in index (breaking change) (#101)
  - Extend list of inmanta reserved keywords
 
 # v 0.0.2

--- a/README.md
+++ b/README.md
@@ -71,12 +71,12 @@ relation = EntityRelation(
     name="tests",
     path=[module.name],
     entity=entity,
-    arity=(0, None),
+    cardinality=(0, None),
     peer=EntityRelation(
         name="",
         path=[module.name],
         entity=entity,
-        arity=(0, 0),
+        cardinality=(0, 0),
     ),
 )
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ module_builder = InmantaModuleBuilder(module)
 entity = Entity(
     name="Test",
     path=[module.name],
-    attributes=[
+    fields=[
         Attribute(
             name="test",
             inmanta_type=InmantaPrimitiveList("string"),
@@ -63,7 +63,7 @@ implement = Implement(
 index = Index(
     path=[module.name],
     entity=entity,
-    attributes=entity.attributes,
+    fields=entity.attributes,
     description="This is a test index",
 )
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ entity = Entity(
     fields=[
         Attribute(
             name="test",
-            inmanta_type=InmantaPrimitiveList("string"),
-            default="[]",
+            inmanta_type="string",
             description="This is a test attribute",
         )
     ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "inmanta-module-factory"
-version = "0.0.5"
+version = "1.0.0"
 description = "Library for building inmanta modules with python code"
 authors = ["Inmanta <code@inmanta.com>"]
 license = "Apache-2.0"

--- a/src/inmanta_module_factory/inmanta/__init__.py
+++ b/src/inmanta_module_factory/inmanta/__init__.py
@@ -16,3 +16,16 @@
     Contact: code@inmanta.com
     Author: Inmanta
 """
+from inmanta_module_factory.inmanta.attribute import Attribute  # noqa: F401
+from inmanta_module_factory.inmanta.entity import Entity  # noqa: F401
+from inmanta_module_factory.inmanta.entity_field import EntityField  # noqa: F401
+from inmanta_module_factory.inmanta.entity_relation import EntityRelation  # noqa: F401
+from inmanta_module_factory.inmanta.implement import Implement  # noqa: F401
+from inmanta_module_factory.inmanta.implementation import Implementation  # noqa: F401
+from inmanta_module_factory.inmanta.index import Index  # noqa: F401
+from inmanta_module_factory.inmanta.module import Module  # noqa: F401
+from inmanta_module_factory.inmanta.module_element import (  # noqa: F401
+    DummyModuleElement,
+    ModuleElement,
+)
+from inmanta_module_factory.inmanta.plugin import Plugin, PluginArgument  # noqa: F401

--- a/src/inmanta_module_factory/inmanta/attribute.py
+++ b/src/inmanta_module_factory/inmanta/attribute.py
@@ -20,6 +20,8 @@ from typing import Optional, Union
 
 from typing_extensions import Literal
 
+from inmanta_module_factory.inmanta.entity import Entity, EntityField
+
 InmantaPrimitiveType = Literal["string", "int", "float", "number", "bool"]
 
 
@@ -34,7 +36,7 @@ class InmantaPrimitiveList:
 InmantaAttributeType = Union[Literal["dict", "any"], InmantaPrimitiveType, InmantaPrimitiveList]
 
 
-class Attribute:
+class Attribute(EntityField):
     def __init__(
         self,
         name: str,
@@ -42,6 +44,7 @@ class Attribute:
         optional: bool = False,
         default: Optional[str] = None,
         description: Optional[str] = None,
+        entity: Optional[Entity] = None,
     ) -> None:
         """
         :param name: The name of the attribute
@@ -50,7 +53,7 @@ class Attribute:
         :param default: Whether this attribute has a default value or not
         :param description: A description of the attribute to add in the docstring
         """
-        self.name = name
+        EntityField.__init__(self, name, entity)
         self._inmanta_type = inmanta_type
         self.optional = optional
         self.default = default

--- a/src/inmanta_module_factory/inmanta/attribute.py
+++ b/src/inmanta_module_factory/inmanta/attribute.py
@@ -20,7 +20,8 @@ from typing import Optional, Union
 
 from typing_extensions import Literal
 
-from inmanta_module_factory.inmanta.entity import Entity, EntityField
+from inmanta_module_factory.inmanta import entity as inmanta_entity
+from inmanta_module_factory.inmanta import entity_field
 
 InmantaPrimitiveType = Literal["string", "int", "float", "number", "bool"]
 
@@ -36,7 +37,7 @@ class InmantaPrimitiveList:
 InmantaAttributeType = Union[Literal["dict", "any"], InmantaPrimitiveType, InmantaPrimitiveList]
 
 
-class Attribute(EntityField):
+class Attribute(entity_field.EntityField):
     def __init__(
         self,
         name: str,
@@ -44,7 +45,7 @@ class Attribute(EntityField):
         optional: bool = False,
         default: Optional[str] = None,
         description: Optional[str] = None,
-        entity: Optional[Entity] = None,
+        entity: Optional["inmanta_entity.Entity"] = None,
     ) -> None:
         """
         :param name: The name of the attribute
@@ -53,7 +54,7 @@ class Attribute(EntityField):
         :param default: Whether this attribute has a default value or not
         :param description: A description of the attribute to add in the docstring
         """
-        EntityField.__init__(self, name, entity)
+        entity_field.EntityField.__init__(self, name, entity)
         self._inmanta_type = inmanta_type
         self.optional = optional
         self.default = default

--- a/src/inmanta_module_factory/inmanta/attribute.py
+++ b/src/inmanta_module_factory/inmanta/attribute.py
@@ -53,6 +53,7 @@ class Attribute(entity_field.EntityField):
         :param optional: Whether this attribute is optional or not
         :param default: Whether this attribute has a default value or not
         :param description: A description of the attribute to add in the docstring
+        :param entity: The entity this attribute is a part of
         """
         entity_field.EntityField.__init__(self, name, entity)
         self._inmanta_type = inmanta_type

--- a/src/inmanta_module_factory/inmanta/entity.py
+++ b/src/inmanta_module_factory/inmanta/entity.py
@@ -20,24 +20,8 @@ from textwrap import indent
 from typing import List, Optional, Sequence, Set
 
 from inmanta_module_factory.helpers.const import INDENT_PREFIX
-from inmanta_module_factory.inmanta import attribute, entity_relation
+from inmanta_module_factory.inmanta import attribute, entity_field, entity_relation
 from inmanta_module_factory.inmanta.module_element import ModuleElement
-
-
-class EntityField:
-    def __init__(self, name: str, entity: Optional["Entity"] = None) -> None:
-        self.name = name
-        self._entity = entity
-        if self._entity is not None:
-            self._entity.attach_field(self)
-
-    @property
-    def entity(self) -> "Entity":
-        assert self._entity is not None
-        return self._entity
-
-    def attach_entity(self, entity: "Entity") -> None:
-        self._entity = entity
 
 
 class Entity(ModuleElement):
@@ -45,7 +29,7 @@ class Entity(ModuleElement):
         self,
         name: str,
         path: List[str],
-        fields: Optional[Sequence[EntityField]] = None,
+        fields: Optional[Sequence["entity_field.EntityField"]] = None,
         parents: Optional[Sequence["Entity"]] = None,
         description: Optional[str] = None,
     ) -> None:
@@ -63,7 +47,7 @@ class Entity(ModuleElement):
             field.attach_entity(self)
         self.parents = parents or []
 
-    def attach_field(self, field: EntityField) -> None:
+    def attach_field(self, field: "entity_field.EntityField") -> None:
         self.fields.add(field)
 
     @property

--- a/src/inmanta_module_factory/inmanta/entity.py
+++ b/src/inmanta_module_factory/inmanta/entity.py
@@ -17,14 +17,11 @@
     Author: Inmanta
 """
 from textwrap import indent
-from typing import TYPE_CHECKING, List, Optional, Sequence, Set
+from typing import List, Optional, Sequence, Set
 
 from inmanta_module_factory.helpers.const import INDENT_PREFIX
+from inmanta_module_factory.inmanta import attribute, entity_relation
 from inmanta_module_factory.inmanta.module_element import ModuleElement
-
-if TYPE_CHECKING:
-    from inmanta_module_factory.inmanta.attribute import Attribute
-    from inmanta_module_factory.inmanta.entity_relation import EntityRelation
 
 
 class EntityField:
@@ -70,16 +67,12 @@ class Entity(ModuleElement):
         self.fields.add(field)
 
     @property
-    def attributes(self) -> List["Attribute"]:
-        from inmanta_module_factory.inmanta.attribute import Attribute
-
-        return [field for field in self.fields if isinstance(field, Attribute)]
+    def attributes(self) -> List["attribute.Attribute"]:
+        return [field for field in self.fields if isinstance(field, attribute.Attribute)]
 
     @property
-    def relations(self) -> List["EntityRelation"]:
-        from inmanta_module_factory.inmanta.entity_relation import EntityRelation
-
-        return [field for field in self.fields if isinstance(field, EntityRelation)]
+    def relations(self) -> List["entity_relation.EntityRelation"]:
+        return [field for field in self.fields if isinstance(field, entity_relation.EntityRelation)]
 
     def _ordering_key(self) -> str:
         return self.name
@@ -97,9 +90,9 @@ class Entity(ModuleElement):
     def docstring(self) -> str:
         doc = super().docstring()
 
-        for attribute in sorted(self.attributes, key=lambda attribute: attribute.name):
-            description = attribute.description or ""
-            doc += f":attr {attribute.name}: {description}\n"
+        for x_attribute in sorted(self.attributes, key=lambda x_attribute: x_attribute.name):
+            description = x_attribute.description or ""
+            doc += f":attr {x_attribute.name}: {description}\n"
 
         for relation in sorted(self.relations, key=lambda relation: relation.name):
             description = relation.description or ""

--- a/src/inmanta_module_factory/inmanta/entity.py
+++ b/src/inmanta_module_factory/inmanta/entity.py
@@ -37,7 +37,9 @@ class Entity(ModuleElement):
         An entity definition.
         :param name: The name of the entity
         :param path: The place in the module where the entity should be printed out
-        :param fields: A list of all the attributes of this entity
+        :param fields: A list of all the attributes and relations of this entity.
+            All the fields provided here will be attached to this entity using their
+            method `attach_entity`.
         :param parents: A list of all the entities this one inherit from
         :param description: A description of this entity, to be added in its docstring
         """

--- a/src/inmanta_module_factory/inmanta/entity_field.py
+++ b/src/inmanta_module_factory/inmanta/entity_field.py
@@ -23,6 +23,15 @@ from inmanta_module_factory.inmanta import entity as inmanta_entity
 
 class EntityField:
     def __init__(self, name: str, entity: Optional["inmanta_entity.Entity"] = None) -> None:
+        """
+        A base class for the entity attributes and relations
+        :param name: The name of the class field
+        :param entity: The entity this field is a member of
+            If the entity is provided here, the field will be automatically attached to the
+            entity as well.  If you don't provide the entity here, the method `attach_entity`
+            has to be called later on.  The constructor of `Entity` calls this method
+            automatically.
+        """
         self.name: str = name
         self._entity = entity
         if self._entity is not None:

--- a/src/inmanta_module_factory/inmanta/entity_field.py
+++ b/src/inmanta_module_factory/inmanta/entity_field.py
@@ -1,0 +1,37 @@
+"""
+    Copyright 2021 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+    Author: Inmanta
+"""
+from typing import Optional
+
+from inmanta_module_factory.inmanta import entity as inmanta_entity
+
+
+class EntityField:
+    def __init__(self, name: str, entity: Optional["inmanta_entity.Entity"] = None) -> None:
+        self.name: str = name
+        self._entity = entity
+        if self._entity is not None:
+            self._entity.attach_field(self)
+
+    @property
+    def entity(self) -> "inmanta_entity.Entity":
+        assert self._entity is not None
+        return self._entity
+
+    def attach_entity(self, entity: "inmanta_entity.Entity") -> None:
+        self._entity = entity

--- a/src/inmanta_module_factory/inmanta/entity_relation.py
+++ b/src/inmanta_module_factory/inmanta/entity_relation.py
@@ -18,31 +18,31 @@
 """
 from typing import List, Optional, Set, Tuple
 
-from inmanta_module_factory.inmanta.entity import Entity
+from inmanta_module_factory.inmanta.entity import Entity, EntityField
 from inmanta_module_factory.inmanta.module_element import ModuleElement
 
 
-class EntityRelation(ModuleElement):
+class EntityRelation(EntityField, ModuleElement):
     def __init__(
         self,
         name: str,
         path: List[str],
-        entity: Entity,
         cardinality: Tuple[int, Optional[int]],
         description: Optional[str] = None,
         peer: Optional["EntityRelation"] = None,
+        entity: Optional[Entity] = None,
     ) -> None:
         """
         A relation statement (or rather half of it).
         :param name: The name of the relation
         :param path: The path in the module where the relation should be printed
-        :param entity: The entity this relations belongs to
         :param cardinality: The multiplicity of the relation, a tuple contianing the min and max
         :param description: A description of the relation
         :param peer: The peer relation, which goes on the other end of "--"
+        :param entity: The entity this relations belongs to
         """
-        super().__init__(name, path, description)
-        self.entity = entity
+        ModuleElement.__init__(self, name, path, description)
+        EntityField.__init__(self, name, entity)
         self._peer = peer
         if self._peer is not None:
             self._peer._peer = self

--- a/src/inmanta_module_factory/inmanta/entity_relation.py
+++ b/src/inmanta_module_factory/inmanta/entity_relation.py
@@ -18,11 +18,12 @@
 """
 from typing import List, Optional, Set, Tuple
 
-from inmanta_module_factory.inmanta.entity import Entity, EntityField
+from inmanta_module_factory.inmanta import entity as inmanta_entity
+from inmanta_module_factory.inmanta import entity_field
 from inmanta_module_factory.inmanta.module_element import ModuleElement
 
 
-class EntityRelation(EntityField, ModuleElement):
+class EntityRelation(entity_field.EntityField, ModuleElement):
     def __init__(
         self,
         name: str,
@@ -30,7 +31,7 @@ class EntityRelation(EntityField, ModuleElement):
         cardinality: Tuple[int, Optional[int]],
         description: Optional[str] = None,
         peer: Optional["EntityRelation"] = None,
-        entity: Optional[Entity] = None,
+        entity: Optional["inmanta_entity.Entity"] = None,
     ) -> None:
         """
         A relation statement (or rather half of it).
@@ -41,8 +42,8 @@ class EntityRelation(EntityField, ModuleElement):
         :param peer: The peer relation, which goes on the other end of "--"
         :param entity: The entity this relations belongs to
         """
+        entity_field.EntityField.__init__(self, name, entity)
         ModuleElement.__init__(self, name, path, description)
-        EntityField.__init__(self, name, entity)
         self._peer = peer
         if self._peer is not None:
             self._peer._peer = self

--- a/src/inmanta_module_factory/inmanta/entity_relation.py
+++ b/src/inmanta_module_factory/inmanta/entity_relation.py
@@ -28,7 +28,7 @@ class EntityRelation(ModuleElement):
         name: str,
         path: List[str],
         entity: Entity,
-        arity: Tuple[int, Optional[int]],
+        cardinality: Tuple[int, Optional[int]],
         description: Optional[str] = None,
         peer: Optional["EntityRelation"] = None,
     ) -> None:
@@ -37,7 +37,7 @@ class EntityRelation(ModuleElement):
         :param name: The name of the relation
         :param path: The path in the module where the relation should be printed
         :param entity: The entity this relations belongs to
-        :param arity: The multiplicity of the relation, a tuple contianing the min and max
+        :param cardinality: The multiplicity of the relation, a tuple contianing the min and max
         :param description: A description of the relation
         :param peer: The peer relation, which goes on the other end of "--"
         """
@@ -47,9 +47,9 @@ class EntityRelation(ModuleElement):
         if self._peer is not None:
             self._peer._peer = self
 
-        self.arity_min = str(arity[0])
-        self.arity_max = str(arity[1] or "")
-        self._is_single = (arity[1] or 2) == 1
+        self.cardinality_min = str(cardinality[0])
+        self.cardinality_max = str(cardinality[1] or "")
+        self._is_single = (cardinality[1] or 2) == 1
 
     def _ordering_key(self) -> str:
         if self.path_string != self.entity.path_string:
@@ -98,14 +98,14 @@ class EntityRelation(ModuleElement):
             # Peer entity is in another file
             peer_entity_path = self.peer.entity.full_path_string
 
-        arity = f"[{self.arity_min}:{self.arity_max}]"
-        if self.arity_min == self.arity_max:
-            arity = f"[{self.arity_min}]"
+        cardinality = f"[{self.cardinality_min}:{self.cardinality_max}]"
+        if self.cardinality_min == self.cardinality_max:
+            cardinality = f"[{self.cardinality_min}]"
 
-        peer_suffix = f".{self.peer.name} [{self.peer.arity_min}:{self.peer.arity_max}]"
+        peer_suffix = f".{self.peer.name} [{self.peer.cardinality_min}:{self.peer.cardinality_max}]"
         if not self.peer.name:
             peer_suffix = ""
-        elif self.peer.arity_min == self.peer.arity_max:
-            peer_suffix = f".{self.peer.name} [{self.peer.arity_min}]"
+        elif self.peer.cardinality_min == self.peer.cardinality_max:
+            peer_suffix = f".{self.peer.name} [{self.peer.cardinality_min}]"
 
-        return f"{entity_path}.{self.name} {arity} -- {peer_entity_path}{peer_suffix}\n"
+        return f"{entity_path}.{self.name} {cardinality} -- {peer_entity_path}{peer_suffix}\n"

--- a/src/inmanta_module_factory/inmanta/index.py
+++ b/src/inmanta_module_factory/inmanta/index.py
@@ -18,7 +18,8 @@
 """
 from typing import List, Optional, Sequence, Set
 
-from inmanta_module_factory.inmanta.entity import Entity, EntityField
+from inmanta_module_factory.inmanta.entity import Entity
+from inmanta_module_factory.inmanta.entity_field import EntityField
 from inmanta_module_factory.inmanta.module_element import ModuleElement
 
 

--- a/src/inmanta_module_factory/inmanta/index.py
+++ b/src/inmanta_module_factory/inmanta/index.py
@@ -20,8 +20,8 @@ from typing import List, Optional, Set
 
 from inmanta_module_factory.inmanta.attribute import Attribute
 from inmanta_module_factory.inmanta.entity import Entity
-from inmanta_module_factory.inmanta.module_element import ModuleElement
 from inmanta_module_factory.inmanta.entity_relation import EntityRelation
+from inmanta_module_factory.inmanta.module_element import ModuleElement
 
 
 class Index(ModuleElement):

--- a/tests/test_foreign_imports.py
+++ b/tests/test_foreign_imports.py
@@ -39,7 +39,7 @@ def test_foreign_implementation(project: Project) -> None:
     entity = Entity(
         "Test",
         path=[module.name],
-        attributes=[
+        fields=[
             Attribute(
                 name="test",
                 inmanta_type="string",

--- a/tests/test_relation_index.py
+++ b/tests/test_relation_index.py
@@ -1,0 +1,155 @@
+"""
+    Copyright 2021 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+    Author: Inmanta
+"""
+from pathlib import Path
+
+from pytest_inmanta.plugin import Project
+
+from inmanta_module_factory.builder import InmantaModuleBuilder
+from inmanta_module_factory.inmanta.attribute import Attribute
+from inmanta_module_factory.inmanta.entity import Entity
+from inmanta_module_factory.inmanta.entity_relation import EntityRelation
+from inmanta_module_factory.inmanta.implement import Implement
+from inmanta_module_factory.inmanta.implementation import Implementation
+from inmanta_module_factory.inmanta.index import Index
+from inmanta_module_factory.inmanta.module import Module
+import logging
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def test_basic(project: Project) -> None:
+    """
+    This simple test creates a more complex module, with entities, implementations, index, etc.
+    It then validates that the modules can be compiled and that its entities can be used.
+    """
+    module = Module(name="test")
+    module_builder = InmantaModuleBuilder(module)
+
+    base_entity = Entity(
+        "Entity",
+        path=["std"],
+        attributes=[],
+    )
+
+    entity = Entity(
+        "Test",
+        path=[module.name],
+        attributes=[
+            Attribute(
+                name="test",
+                inmanta_type="string",
+                description="This is a test attribute",
+            ),
+        ],
+        description="This is a test entity",
+        parents=[base_entity],
+    )
+
+    entity2 = Entity(
+        "Test2",
+        path=[module.name],
+        attributes=[
+            Attribute(
+                name="test",
+                inmanta_type="string",
+                description="This is a test attribute",
+            ),
+        ],
+        description="This is another test entity",
+        parents=[base_entity],
+    )
+
+    relation = EntityRelation(
+        name="peer",
+        path=[module.name],
+        entity=entity,
+        arity=(1, 1),
+        peer=EntityRelation(
+            name="peer",
+            path=[module.name],
+            entity=entity2,
+            arity=(1, 1),
+        ),
+    )
+
+    implementation = Implementation(
+        name="none",
+        path=["std"],
+        entity=base_entity,
+        content="",
+    )
+
+    implement = Implement(
+        path=[module.name],
+        implementation=implementation,
+        entity=entity,
+    )
+
+    implement2 = Implement(
+        path=[module.name],
+        implementation=implementation,
+        entity=entity2,
+    )
+
+    index = Index(
+        path=[module.name],
+        entity=entity,
+        attributes=[entity.attributes[0]],
+        description="This is a test index",
+    )
+
+    index2 = Index(
+        path=[module.name],
+        entity=entity2,
+        attributes=[entity2.attributes[0]],
+        relations=[relation.peer],
+        description="This is another test index",
+    )
+
+    module_builder.add_module_element(entity)
+    module_builder.add_module_element(entity2)
+    module_builder.add_module_element(relation)
+    module_builder.add_module_element(implement)
+    module_builder.add_module_element(implement2)
+    module_builder.add_module_element(index)
+    module_builder.add_module_element(index2)
+
+    build_location = Path(project._test_project_dir) / "libs"
+    module_builder.generate_module(build_location=build_location)
+
+    LOGGER.debug((build_location / module.name / "model/_init.cf").read_text())
+
+    project.compile(
+        """
+            import test
+
+            t = test::Test(
+                test="a",
+                peer=t2,
+            )
+            t2 = test::Test2(
+                test="b",
+                peer=t,
+            )
+            a = test::Test[test="a"]
+            b = test::Test2[test="b", peer=t]
+        """,
+        no_dedent=False,
+    )

--- a/tests/test_relation_index.py
+++ b/tests/test_relation_index.py
@@ -79,12 +79,12 @@ def test_basic(project: Project) -> None:
         name="peer",
         path=[module.name],
         entity=entity,
-        arity=(1, 1),
+        cardinality=(1, 1),
         peer=EntityRelation(
             name="peer",
             path=[module.name],
             entity=entity2,
-            arity=(1, 1),
+            cardinality=(1, 1),
         ),
     )
 

--- a/tests/test_relation_index.py
+++ b/tests/test_relation_index.py
@@ -44,13 +44,13 @@ def test_basic(project: Project) -> None:
     base_entity = Entity(
         "Entity",
         path=["std"],
-        attributes=[],
+        fields=[],
     )
 
     entity = Entity(
         "Test",
         path=[module.name],
-        attributes=[
+        fields=[
             Attribute(
                 name="test",
                 inmanta_type="string",
@@ -64,7 +64,7 @@ def test_basic(project: Project) -> None:
     entity2 = Entity(
         "Test2",
         path=[module.name],
-        attributes=[
+        fields=[
             Attribute(
                 name="test",
                 inmanta_type="string",
@@ -110,15 +110,14 @@ def test_basic(project: Project) -> None:
     index = Index(
         path=[module.name],
         entity=entity,
-        attributes=[entity.attributes[0]],
+        fields=[entity.attributes[0]],
         description="This is a test index",
     )
 
     index2 = Index(
         path=[module.name],
         entity=entity2,
-        attributes=[entity2.attributes[0]],
-        relations=[relation.peer],
+        fields=[entity2.attributes[0], relation.peer],
         description="This is another test index",
     )
 

--- a/tests/test_relation_index.py
+++ b/tests/test_relation_index.py
@@ -16,6 +16,7 @@
     Contact: code@inmanta.com
     Author: Inmanta
 """
+import logging
 from pathlib import Path
 
 from pytest_inmanta.plugin import Project
@@ -28,8 +29,6 @@ from inmanta_module_factory.inmanta.implement import Implement
 from inmanta_module_factory.inmanta.implementation import Implementation
 from inmanta_module_factory.inmanta.index import Index
 from inmanta_module_factory.inmanta.module import Module
-import logging
-
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests/test_simple_module.py
+++ b/tests/test_simple_module.py
@@ -54,20 +54,22 @@ def test_basic_module(project: Project) -> None:
     entity = Entity(
         "Test",
         path=[module.name],
-        attributes=[
+        fields=[
             Attribute(
                 name="test",
                 inmanta_type=InmantaPrimitiveList("string"),
                 default="[]",
                 description="This is a test list attribute",
             ),
-            Attribute(
-                name="test1",
-                inmanta_type="string",
-                description="This is a test attribute",
-            ),
         ],
         description="This is a test entity",
+    )
+
+    index_attribute = Attribute(
+        name="test1",
+        inmanta_type="string",
+        description="This is a test attribute",
+        entity=entity,
     )
 
     implementation = Implementation(
@@ -87,7 +89,7 @@ def test_basic_module(project: Project) -> None:
     index = Index(
         path=[module.name],
         entity=entity,
-        attributes=entity.attributes[1:2],
+        fields=[index_attribute],
         description="This is a test index",
     )
 

--- a/tests/test_simple_module.py
+++ b/tests/test_simple_module.py
@@ -76,7 +76,7 @@ def test_basic_module(project: Project) -> None:
         name="test",
         path=[module.name],
         entity=entity,
-        content=f"std::print(self.{entity.attributes[1].name})",
+        content=f"std::print(self.{index_attribute.name})",
         description="This is a test implementation",
     )
 

--- a/tests/test_simple_module.py
+++ b/tests/test_simple_module.py
@@ -95,12 +95,12 @@ def test_basic_module(project: Project) -> None:
         name="tests",
         path=[module.name],
         entity=entity,
-        arity=(0, None),
+        cardinality=(0, None),
         peer=EntityRelation(
             name="",
             path=[module.name],
             entity=entity,
-            arity=(0, 0),
+            cardinality=(0, 0),
         ),
     )
 


### PR DESCRIPTION
# Description

This tool didn't have support for relations in index.  This PR does it.  This is a breaking change as it changes the definition of the Index constructor.

While I am doing a breaking change, I also renamed the `arity` attribute of the relation to `cardinality` which is more clear.

closes #101 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
