### PR TITLE
Undo version bump and fix changelog

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.5
+current_version = 0.1.0
 tag = False
 commit = False
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v 1.0.0 (?)
+# v 0.1.0 (?)
 
  - Renaming `arity` to `cardinality` in relations
  - Add support for relations in index (breaking change) (#101)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "inmanta-module-factory"
-version = "0.0.5"
+version = "0.1.0"
 description = "Library for building inmanta modules with python code"
 authors = ["Inmanta <code@inmanta.com>"]
 license = "Apache-2.0"

--- a/src/inmanta_module_factory/__init__.py
+++ b/src/inmanta_module_factory/__init__.py
@@ -16,4 +16,4 @@
     Contact: code@inmanta.com
     Author: Inmanta
 """
-__version__ = "0.0.5"
+__version__ = "0.1.0"


### PR DESCRIPTION
# Description

In the last PR I messed up the release process by manually bumping the version of `pyproject.toml`.  This should hopefully fix it?

