### PR TITLE
Issue/109 typedef support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v 1.2.0 (?)
 Changes in this release:
  - Added support for typedef statement. (#109)
+ - refactored the type hierarchy
 
 # v 1.1.0 (2022-03-18)
 Changes in this release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v 1.2.0 (?)
 Changes in this release:
+ - Added support for typedef statement. (#109)
 
 # v 1.1.0 (2022-03-18)
 Changes in this release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
-# v 1.2.0 (?)
+# v 2.0.0 (?)
 Changes in this release:
  - Added support for typedef statement. (#109)
- - refactored the type hierarchy
+ - Refactored the type hierarchy.
 
 # v 1.1.0 (2022-03-18)
 Changes in this release:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This package contains a few python classes that represents components of an inma
  - `EntityRelation`: Represents an relation between two entities.
  - `Index`: Represents an `index` statement.
  - `Attribute`: Represents an entity attribute.
+ - `TypeDef`: Represents a `typedef` statement.
  - `Module`: Represents the module itself.
  - `Plugin`: Represents a plugin.
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ from inmanta_module_factory.inmanta.implement import Implement
 from inmanta_module_factory.inmanta.implementation import Implementation
 from inmanta_module_factory.inmanta.index import Index
 from inmanta_module_factory.inmanta.module import Module
+from inmanta_module_factory.inmanta.types import InmantaStringType
 from inmanta_module_factory.builder import InmantaModuleBuilder
 
 
@@ -39,7 +40,7 @@ entity = Entity(
     fields=[
         Attribute(
             name="test",
-            inmanta_type="string",
+            inmanta_type=InmantaStringType,
             description="This is a test attribute",
         )
     ],

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,0 +1,2 @@
+[experimental]
+new-installer = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ types-PyYAML = "^6.0.5"
 
 [tool.black]
 line-length = 128
-target-version = ['py36', 'py37', 'py38', 'py39']
+target-version = ['py36', 'py37', 'py38']
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ types-PyYAML = "^6.0.5"
 
 [tool.black]
 line-length = 128
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py36', 'py37', 'py38', 'py39']
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/src/inmanta_module_factory/inmanta/__init__.py
+++ b/src/inmanta_module_factory/inmanta/__init__.py
@@ -29,3 +29,17 @@ from inmanta_module_factory.inmanta.module_element import (  # noqa: F401
     ModuleElement,
 )
 from inmanta_module_factory.inmanta.plugin import Plugin, PluginArgument  # noqa: F401
+from inmanta_module_factory.inmanta.typedef import TypeDef  # noqa: F401
+from inmanta_module_factory.inmanta.types import (  # noqa: F401
+    InmantaAdvancedType,
+    InmantaAnyType,
+    InmantaBaseType,
+    InmantaBooleanType,
+    InmantaDictType,
+    InmantaIntegerType,
+    InmantaListType,
+    InmantaNumberType,
+    InmantaPrimitiveType,
+    InmantaStringType,
+    InmantaType,
+)

--- a/src/inmanta_module_factory/inmanta/attribute.py
+++ b/src/inmanta_module_factory/inmanta/attribute.py
@@ -17,6 +17,7 @@
     Author: Inmanta
 """
 from typing import Optional, Union
+
 from typing_extensions import Literal
 
 from inmanta_module_factory.inmanta import entity as inmanta_entity

--- a/src/inmanta_module_factory/inmanta/attribute.py
+++ b/src/inmanta_module_factory/inmanta/attribute.py
@@ -16,32 +16,18 @@
     Contact: code@inmanta.com
     Author: Inmanta
 """
-from typing import Optional, Union
+from typing import Optional
 
-from typing_extensions import Literal
-
+from inmanta_module_factory.inmanta import typedef
 from inmanta_module_factory.inmanta import entity as inmanta_entity
 from inmanta_module_factory.inmanta import entity_field
-
-InmantaPrimitiveType = Literal["string", "int", "float", "number", "bool"]
-
-
-class InmantaPrimitiveList:
-    def __init__(self, primitive_type: InmantaPrimitiveType) -> None:
-        self.primitive_type = primitive_type
-
-    def __str__(self) -> str:
-        return self.primitive_type + "[]"
-
-
-InmantaAttributeType = Union[Literal["dict", "any"], InmantaPrimitiveType, InmantaPrimitiveList]
 
 
 class Attribute(entity_field.EntityField):
     def __init__(
         self,
         name: str,
-        inmanta_type: InmantaAttributeType,
+        inmanta_type: typedef.InmantaAttributeType,
         optional: bool = False,
         default: Optional[str] = None,
         description: Optional[str] = None,
@@ -63,10 +49,13 @@ class Attribute(entity_field.EntityField):
 
     @property
     def is_list(self) -> bool:
-        return isinstance(self._inmanta_type, InmantaPrimitiveList)
+        return isinstance(self._inmanta_type, typedef.InmantaPrimitiveList)
 
     @property
     def inmanta_type(self) -> str:
+        if isinstance(self._inmanta_type, typedef.TypeDef):
+            return self._inmanta_type.full_path_string
+
         return str(self._inmanta_type)
 
     def __str__(self) -> str:

--- a/src/inmanta_module_factory/inmanta/attribute.py
+++ b/src/inmanta_module_factory/inmanta/attribute.py
@@ -16,18 +16,36 @@
     Contact: code@inmanta.com
     Author: Inmanta
 """
-from typing import Optional
+from typing import Optional, Union
+from typing_extensions import Literal
 
-from inmanta_module_factory.inmanta import typedef
 from inmanta_module_factory.inmanta import entity as inmanta_entity
-from inmanta_module_factory.inmanta import entity_field
+from inmanta_module_factory.inmanta import entity_field, typedef
+
+
+class InmantaPrimitiveList:
+    def __init__(self, primitive_type: "typedef.InmantaBaseType") -> None:
+        self._primitive_type = primitive_type
+
+    @property
+    def primitive_type(self) -> str:
+        if isinstance(self._primitive_type, typedef.TypeDef):
+            return self._primitive_type.full_path_string
+
+        return self._primitive_type
+
+    def __str__(self) -> str:
+        return self.primitive_type + "[]"
+
+
+InmantaAttributeType = Union[Literal["dict", "any"], typedef.InmantaBaseType, InmantaPrimitiveList]
 
 
 class Attribute(entity_field.EntityField):
     def __init__(
         self,
         name: str,
-        inmanta_type: typedef.InmantaAttributeType,
+        inmanta_type: InmantaAttributeType,
         optional: bool = False,
         default: Optional[str] = None,
         description: Optional[str] = None,
@@ -49,7 +67,7 @@ class Attribute(entity_field.EntityField):
 
     @property
     def is_list(self) -> bool:
-        return isinstance(self._inmanta_type, typedef.InmantaPrimitiveList)
+        return isinstance(self._inmanta_type, InmantaPrimitiveList)
 
     @property
     def inmanta_type(self) -> str:

--- a/src/inmanta_module_factory/inmanta/attribute.py
+++ b/src/inmanta_module_factory/inmanta/attribute.py
@@ -73,7 +73,10 @@ class Attribute(entity_field.EntityField):
     @property
     def inmanta_type(self) -> str:
         if isinstance(self._inmanta_type, typedef.TypeDef):
-            return self._inmanta_type.full_path_string
+            if self._inmanta_type.path_string == self.entity.path_string:
+                return self._inmanta_type.name
+            else:
+                return self._inmanta_type.full_path_string
 
         return str(self._inmanta_type)
 

--- a/src/inmanta_module_factory/inmanta/entity.py
+++ b/src/inmanta_module_factory/inmanta/entity.py
@@ -71,6 +71,15 @@ class Entity(ModuleElement):
                 # Parent is in a different file
                 imports.add(parent.path_string)
 
+        for attr in self.attributes:
+            if not attr.inmanta_type.path_string:
+                # This is a primitive type, it can not be imported
+                continue
+
+            if self.path_string != attr.inmanta_type.path_string:
+                # Attribute type is defined in another file
+                imports.add(attr.inmanta_type.path_string)
+
         return imports
 
     def docstring(self) -> str:

--- a/src/inmanta_module_factory/inmanta/entity_relation.py
+++ b/src/inmanta_module_factory/inmanta/entity_relation.py
@@ -110,7 +110,7 @@ class EntityRelation(entity_field.EntityField, ModuleElement):
             peer_suffix = f".{self.peer.name} [{self.peer.cardinality_min}]"
 
         docstring = self.docstring()
-        if docstring:
-            docstring = f'"""\n{docstring}\n"""\n'
+        if docstring or self.peer.docstring():
+            docstring = f'"""\n{docstring}Peer relation: {self.peer.docstring()}"""\n'
 
         return f"{entity_path}.{self.name} {cardinality} -- {peer_entity_path}{peer_suffix}\n{docstring}"

--- a/src/inmanta_module_factory/inmanta/typedef.py
+++ b/src/inmanta_module_factory/inmanta/typedef.py
@@ -42,7 +42,7 @@ class TypeDef(ModuleElement):
         :param description: Some explanation about what this constraint does
         """
         super().__init__(name, path, description)
-        self.base_type = base_type
+        self._base_type = base_type
         self.constraint = constraint
 
     def _ordering_key(self) -> str:
@@ -51,17 +51,25 @@ class TypeDef(ModuleElement):
     def _get_derived_imports(self) -> Set[str]:
         imports: Set[str] = set()
 
-        if isinstance(self.base_type, TypeDef):
-            if self.base_type.path != self.path:
+        if isinstance(self._base_type, TypeDef):
+            if self._base_type.path_string != self.path_string:
                 # Base type is defined in another file
-                imports.add(self.base_type.path_string)
+                imports.add(self._base_type.path_string)
 
         return imports
 
-    def __str__(self) -> str:
-        base_type_expression = self.base_type.full_path_string if isinstance(self.base_type, TypeDef) else self.base_type
+    @property
+    def base_type(self) -> str:
+        if isinstance(self._base_type, TypeDef):
+            if self._base_type.path_string == self.path_string:
+                return self._base_type.name
+            else:
+                return self._base_type.full_path_string
 
-        stmt = f"typedef {self.name} as {base_type_expression} matching {self.constraint}"
+        return self._base_type
+
+    def __str__(self) -> str:
+        stmt = f"typedef {self.name} as {self.base_type} matching {self.constraint}"
         docstring = self.docstring()
         if docstring:
             docstring = f'"""\n{docstring}"""\n'

--- a/src/inmanta_module_factory/inmanta/typedef.py
+++ b/src/inmanta_module_factory/inmanta/typedef.py
@@ -1,0 +1,89 @@
+"""
+    Copyright 2021 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+    Author: Inmanta
+"""
+from typing import List, Literal, Optional, Set, Union
+
+from inmanta_module_factory.inmanta.module_element import ModuleElement
+
+InmantaPrimitiveType = Literal["string", "int", "number", "bool"]
+
+
+class TypeDef(ModuleElement):
+    def __init__(
+        self,
+        name: str,
+        path: List[str],
+        base_type: "InmantaBaseType",
+        constraint: str,
+        description: Optional[str] = None,
+    ) -> None:
+        """
+        :param name: The name of this type definition
+        :param path: The path to the location in this module where the typedef should be defined
+        :param base_type: The base type this typedef adds constraints on
+        :param constraint: The constraint to add to this typedef
+        :param description: Some explanation about what this constraint does
+        """
+        super().__init__(name, path, description)
+        self.base_type = base_type
+        self.constraint = constraint
+
+    def _ordering_key(self) -> str:
+        return f"{chr(0)}.typedef.{self.name}"
+
+    def _get_derived_imports(self) -> Set[str]:
+        imports: Set[str] = set()
+
+        if isinstance(self.base_type, TypeDef):
+            if self.base_type.path != self.path:
+                # Base type is defined in another file
+                imports.add(self.base_type.path_string)
+
+        return imports
+
+    def __str__(self) -> str:
+        base_type_expression = (
+            self.base_type.full_path_string
+            if isinstance(self.base_type, TypeDef)
+            else self.base_type
+        )
+
+        stmt = f"typedef {self.name} as {base_type_expression} matching {self.constraint}"
+        docstring = self.docstring()
+        if docstring:
+            docstring = f'"""\n{docstring}"""\n'
+
+        return f"{stmt}\n{docstring}"
+
+class InmantaPrimitiveList:
+    def __init__(self, primitive_type: "InmantaBaseType") -> None:
+        self._primitive_type = primitive_type
+
+    @property
+    def primitive_type(self) -> str:
+        if isinstance(self._primitive_type, TypeDef):
+            return self._primitive_type.full_path_string
+
+        return self._primitive_type
+
+    def __str__(self) -> str:
+        return self.primitive_type + "[]"
+
+
+InmantaBaseType = Union[InmantaPrimitiveType, TypeDef]
+InmantaAttributeType = Union[Literal["dict", "any"], InmantaBaseType, InmantaPrimitiveList]

--- a/src/inmanta_module_factory/inmanta/typedef.py
+++ b/src/inmanta_module_factory/inmanta/typedef.py
@@ -23,6 +23,11 @@ from inmanta_module_factory.inmanta.types import InmantaBaseType
 
 
 class TypeDef(ModuleElement, InmantaBaseType):
+    """
+    This class represents a typedef statement.  The typedef has to be added to the module by the user.
+    It can be used as base type for another typedef or as item type for a list.
+    """
+
     def __init__(
         self,
         name: str,

--- a/src/inmanta_module_factory/inmanta/typedef.py
+++ b/src/inmanta_module_factory/inmanta/typedef.py
@@ -16,7 +16,8 @@
     Contact: code@inmanta.com
     Author: Inmanta
 """
-from typing import List, Literal, Optional, Set, Union
+from typing import List, Optional, Set, Union
+from typing_extensions import Literal
 
 from inmanta_module_factory.inmanta.module_element import ModuleElement
 
@@ -57,11 +58,7 @@ class TypeDef(ModuleElement):
         return imports
 
     def __str__(self) -> str:
-        base_type_expression = (
-            self.base_type.full_path_string
-            if isinstance(self.base_type, TypeDef)
-            else self.base_type
-        )
+        base_type_expression = self.base_type.full_path_string if isinstance(self.base_type, TypeDef) else self.base_type
 
         stmt = f"typedef {self.name} as {base_type_expression} matching {self.constraint}"
         docstring = self.docstring()
@@ -70,20 +67,5 @@ class TypeDef(ModuleElement):
 
         return f"{stmt}\n{docstring}"
 
-class InmantaPrimitiveList:
-    def __init__(self, primitive_type: "InmantaBaseType") -> None:
-        self._primitive_type = primitive_type
-
-    @property
-    def primitive_type(self) -> str:
-        if isinstance(self._primitive_type, TypeDef):
-            return self._primitive_type.full_path_string
-
-        return self._primitive_type
-
-    def __str__(self) -> str:
-        return self.primitive_type + "[]"
-
 
 InmantaBaseType = Union[InmantaPrimitiveType, TypeDef]
-InmantaAttributeType = Union[Literal["dict", "any"], InmantaBaseType, InmantaPrimitiveList]

--- a/src/inmanta_module_factory/inmanta/typedef.py
+++ b/src/inmanta_module_factory/inmanta/typedef.py
@@ -17,6 +17,7 @@
     Author: Inmanta
 """
 from typing import List, Optional, Set, Union
+
 from typing_extensions import Literal
 
 from inmanta_module_factory.inmanta.module_element import ModuleElement

--- a/src/inmanta_module_factory/inmanta/types.py
+++ b/src/inmanta_module_factory/inmanta/types.py
@@ -1,0 +1,94 @@
+"""
+    Copyright 2021 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+    Author: Inmanta
+"""
+from typing import Literal
+
+
+class InmantaType:
+    """
+    Base class for all inmanta attribute type representations.
+    """
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    @property
+    def path_string(self) -> str:
+        """
+        This returns the path of this entity's file in this module.  The name of the module
+        is the first element of the path.
+        """
+        return ""
+
+    @property
+    def full_path_string(self) -> str:
+        """
+        This returns the path of this entity in this module.  The difference with path_string
+        is that this one contains the name of the entity at the end.
+        """
+        return self.name
+
+    def __str__(self) -> str:
+        return self.name
+
+
+class InmantaAdvancedType(InmantaType, str):
+    def __init__(self, name: Literal["dict", "any"]) -> None:
+        super().__init__(name)
+
+
+InmantaDictType = InmantaAdvancedType("dict")
+InmantaAnyType = InmantaAdvancedType("any")
+
+
+class InmantaBaseType(InmantaType):
+    def __init__(self, name: str) -> None:
+        super().__init__(name)
+
+
+class InmantaPrimitiveType(InmantaBaseType, str):
+    def __init__(self, name: Literal["int", "bool", "number", "string"]) -> None:
+        super().__init__(name)
+
+
+InmantaIntegerType = InmantaPrimitiveType("int")
+InmantaBooleanType = InmantaPrimitiveType("bool")
+InmantaNumberType = InmantaPrimitiveType("number")
+InmantaStringType = InmantaPrimitiveType("string")
+
+
+class InmantaListType(InmantaType):
+    def __init__(self, item_type: InmantaBaseType) -> None:
+        super().__init__(item_type.name + "[]")
+        self.item_type = item_type
+
+    @property
+    def path_string(self) -> str:
+        """
+        This returns the path of this entity's file in this module.  The name of the module
+        is the first element of the path.
+        """
+        return self.item_type.path_string
+
+    @property
+    def full_path_string(self) -> str:
+        """
+        This returns the path of this entity in this module.  The difference with path_string
+        is that this one contains the name of the entity at the end.
+        """
+        return self.item_type.full_path_string + "[]"

--- a/src/inmanta_module_factory/inmanta/types.py
+++ b/src/inmanta_module_factory/inmanta/types.py
@@ -30,16 +30,18 @@ class InmantaType:
     @property
     def path_string(self) -> str:
         """
-        This returns the path of this entity's file in this module.  The name of the module
-        is the first element of the path.
+        This methods can be used to differentiate typedefs from primitive types
+        A primitive type will always have an empty path_string as it is not defined anywhere
+        in our model.
         """
         return ""
 
     @property
     def full_path_string(self) -> str:
         """
-        This returns the path of this entity in this module.  The difference with path_string
-        is that this one contains the name of the entity at the end.
+        This methods can be used to differentiate typedefs from primitive types
+        A primitive type will always have as full_path_string its name as it has not been defined
+        anywhere in our model.
         """
         return self.name
 
@@ -48,6 +50,10 @@ class InmantaType:
 
 
 class InmantaAdvancedType(InmantaType, str):
+    """
+    This class represents all inmanta primitive types that can not be used as base type typedefs or lists
+    """
+
     def __init__(self, name: Literal["dict", "any"]) -> None:
         super().__init__(name)
 
@@ -57,11 +63,20 @@ InmantaAnyType = InmantaAdvancedType("any")
 
 
 class InmantaBaseType(InmantaType):
+    """
+    This class represents all inmanta types that can be used a base type for typedefs or lists
+    """
+
     def __init__(self, name: str) -> None:
         super().__init__(name)
 
 
 class InmantaPrimitiveType(InmantaBaseType, str):
+    """
+    This class represents all the inmanta primitive types that can be used as base type for typedefs
+    or lists
+    """
+
     def __init__(self, name: Literal["int", "bool", "number", "string"]) -> None:
         super().__init__(name)
 
@@ -73,6 +88,11 @@ InmantaStringType = InmantaPrimitiveType("string")
 
 
 class InmantaListType(InmantaType):
+    """
+    This class represents all list types in inmanta language, a list type is composed of a base type, which
+    is the type of each item of the list.
+    """
+
     def __init__(self, item_type: InmantaBaseType) -> None:
         super().__init__(item_type.name + "[]")
         self.item_type = item_type
@@ -80,15 +100,13 @@ class InmantaListType(InmantaType):
     @property
     def path_string(self) -> str:
         """
-        This returns the path of this entity's file in this module.  The name of the module
-        is the first element of the path.
+        The path_string of a list is the same one as the one of its item type
         """
         return self.item_type.path_string
 
     @property
     def full_path_string(self) -> str:
         """
-        This returns the path of this entity in this module.  The difference with path_string
-        is that this one contains the name of the entity at the end.
+        The full_path_string of a list is the same one as the one of its item type plus "[]"
         """
         return self.item_type.full_path_string + "[]"

--- a/tests/test_foreign_imports.py
+++ b/tests/test_foreign_imports.py
@@ -26,6 +26,7 @@ from inmanta_module_factory.inmanta.entity import Entity
 from inmanta_module_factory.inmanta.implement import Implement
 from inmanta_module_factory.inmanta.implementation import Implementation
 from inmanta_module_factory.inmanta.module import Module
+from inmanta_module_factory.inmanta.types import InmantaStringType
 
 
 def test_foreign_implementation(project: Project) -> None:
@@ -42,7 +43,7 @@ def test_foreign_implementation(project: Project) -> None:
         fields=[
             Attribute(
                 name="test",
-                inmanta_type="string",
+                inmanta_type=InmantaStringType,
                 description="This is a test attribute",
             ),
         ],

--- a/tests/test_relation_index.py
+++ b/tests/test_relation_index.py
@@ -29,6 +29,7 @@ from inmanta_module_factory.inmanta.implement import Implement
 from inmanta_module_factory.inmanta.implementation import Implementation
 from inmanta_module_factory.inmanta.index import Index
 from inmanta_module_factory.inmanta.module import Module
+from inmanta_module_factory.inmanta.types import InmantaStringType
 
 LOGGER = logging.getLogger(__name__)
 
@@ -53,7 +54,7 @@ def test_basic(project: Project) -> None:
         fields=[
             Attribute(
                 name="test",
-                inmanta_type="string",
+                inmanta_type=InmantaStringType,
                 description="This is a test attribute",
             ),
         ],
@@ -67,7 +68,7 @@ def test_basic(project: Project) -> None:
         fields=[
             Attribute(
                 name="test",
-                inmanta_type="string",
+                inmanta_type=InmantaStringType,
                 description="This is a test attribute",
             ),
         ],

--- a/tests/test_simple_module.py
+++ b/tests/test_simple_module.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from pytest_inmanta.plugin import Project
 
 from inmanta_module_factory.builder import InmantaModuleBuilder
-from inmanta_module_factory.inmanta.attribute import Attribute, InmantaPrimitiveList
+from inmanta_module_factory.inmanta.attribute import Attribute
 from inmanta_module_factory.inmanta.entity import Entity
 from inmanta_module_factory.inmanta.entity_relation import EntityRelation
 from inmanta_module_factory.inmanta.implement import Implement
@@ -29,6 +29,7 @@ from inmanta_module_factory.inmanta.implementation import Implementation
 from inmanta_module_factory.inmanta.index import Index
 from inmanta_module_factory.inmanta.module import Module
 from inmanta_module_factory.inmanta.plugin import Plugin, PluginArgument
+from inmanta_module_factory.inmanta.types import InmantaListType, InmantaStringType
 
 
 def test_empty_module(project: Project) -> None:
@@ -57,7 +58,7 @@ def test_basic_module(project: Project) -> None:
         fields=[
             Attribute(
                 name="test",
-                inmanta_type=InmantaPrimitiveList("string"),
+                inmanta_type=InmantaListType(InmantaStringType),
                 default="[]",
                 description="This is a test list attribute",
             ),
@@ -67,7 +68,7 @@ def test_basic_module(project: Project) -> None:
 
     index_attribute = Attribute(
         name="test1",
-        inmanta_type="string",
+        inmanta_type=InmantaStringType,
         description="This is a test attribute",
         entity=entity,
     )
@@ -144,12 +145,12 @@ def test_plugin(project: Project) -> None:
         arguments=[
             PluginArgument(
                 name="world",
-                inmanta_type="string",
+                inmanta_type=InmantaStringType,
             ),
         ],
         return_type=PluginArgument(
             name="",
-            inmanta_type="string",
+            inmanta_type=InmantaStringType,
         ),
         content="""return f"hello {world}" """,
     )

--- a/tests/test_typedefs.py
+++ b/tests/test_typedefs.py
@@ -183,7 +183,7 @@ def test_composed(project: Project) -> None:
 
     typedef = TypeDef(
         "test",
-        path=[module.name],
+        path=[module.name, "types"],
         base_type="string",
         constraint="std::length(self) >= 10",
         description="String of minimum 10 characters",
@@ -197,6 +197,14 @@ def test_composed(project: Project) -> None:
         description="String of maximum 10 characters",
     )
 
+    typedef2 = TypeDef(
+        "test2",
+        path=[module.name],
+        base_type=typedef,
+        constraint='std::validate_type("pydantic.constr", self, {"regex": "[a-z]+"})',
+        description="String of alphabetical characters",
+    )
+
     entity = Entity(
         "Test",
         path=[module.name],
@@ -204,6 +212,12 @@ def test_composed(project: Project) -> None:
             Attribute(
                 name="test",
                 inmanta_type=typedef1,
+                description="This is a test attribute",
+            ),
+            Attribute(
+                name="test2",
+                inmanta_type=typedef2,
+                default='"abcdefghij"',
                 description="This is a test attribute",
             ),
         ],
@@ -223,6 +237,7 @@ def test_composed(project: Project) -> None:
 
     module_builder.add_module_element(typedef)
     module_builder.add_module_element(typedef1)
+    module_builder.add_module_element(typedef2)
     module_builder.add_module_element(entity)
     module_builder.add_module_element(implement)
 

--- a/tests/test_typedefs.py
+++ b/tests/test_typedefs.py
@@ -1,0 +1,266 @@
+"""
+    Copyright 2021 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+    Author: Inmanta
+"""
+import pytest
+import inmanta
+from pathlib import Path
+
+from pytest_inmanta.plugin import Project
+
+from inmanta_module_factory.builder import InmantaModuleBuilder
+from inmanta_module_factory.inmanta.attribute import Attribute, InmantaPrimitiveList
+from inmanta_module_factory.inmanta.entity import Entity
+from inmanta_module_factory.inmanta.implement import Implement
+from inmanta_module_factory.inmanta.implementation import Implementation
+from inmanta_module_factory.inmanta.module import Module
+from inmanta_module_factory.inmanta.typedef import TypeDef
+
+
+def test_simple(project: Project) -> None:
+    """
+    This simple test creates a simple module containing a type definition.  This type definition
+    is used for an attribute of the single entity of this module.
+    """
+    module = Module(name="test")
+    module_builder = InmantaModuleBuilder(module)
+
+    typedef = TypeDef(
+        "test",
+        path=[module.name],
+        base_type="string",
+        constraint="std::length(self) > 10",
+        description="String of minimum 10 characters",
+    )
+
+    entity = Entity(
+        "Test",
+        path=[module.name],
+        fields=[
+            Attribute(
+                name="test",
+                inmanta_type=typedef,
+                description="This is a test attribute",
+            ),
+        ],
+        description="This is a test entity",
+    )
+
+    implement = Implement(
+        path=[module.name],
+        implementation=Implementation(
+            name="none",
+            path=["std"],
+            entity=entity,
+            content="",
+        ),
+        entity=entity,
+    )
+
+    module_builder.add_module_element(typedef)
+    module_builder.add_module_element(entity)
+    module_builder.add_module_element(implement)
+
+    module_builder.generate_module(Path(project._test_project_dir) / "libs")
+
+    project.compile(
+        """
+            import test
+
+            test::Test(
+                test="01234567890",
+            )
+        """,
+        no_dedent=False,
+    )
+
+    # A string shorter than 10 character should fail
+    with pytest.raises(inmanta.ast.AttributeException):
+        project.compile(
+            """
+                import test
+
+                test::Test(
+                    test="0123456789",
+                )
+            """,
+            no_dedent=False,
+    )
+
+
+def test_list(project: Project) -> None:
+    """
+    This simple test creates a simple module containing a type definition.  This type definition
+    is used for a list attribute of the single entity of this module.
+    """
+    module = Module(name="test")
+    module_builder = InmantaModuleBuilder(module)
+
+    typedef = TypeDef(
+        "test",
+        path=[module.name],
+        base_type="string",
+        constraint="std::length(self) > 10",
+        description="String of minimum 10 characters",
+    )
+
+    entity = Entity(
+        "Test",
+        path=[module.name],
+        fields=[
+            Attribute(
+                name="test",
+                inmanta_type=InmantaPrimitiveList(typedef),
+                description="This is a test attribute",
+            ),
+        ],
+        description="This is a test entity",
+    )
+
+    implement = Implement(
+        path=[module.name],
+        implementation=Implementation(
+            name="none",
+            path=["std"],
+            entity=entity,
+            content="",
+        ),
+        entity=entity,
+    )
+
+    module_builder.add_module_element(typedef)
+    module_builder.add_module_element(entity)
+    module_builder.add_module_element(implement)
+
+    module_builder.generate_module(Path(project._test_project_dir) / "libs")
+
+    project.compile(
+        """
+            import test
+
+            test::Test(
+                test=["01234567890"],
+            )
+        """,
+        no_dedent=False,
+    )
+
+    # A string shorter than 10 character should fail
+    with pytest.raises(inmanta.ast.AttributeException):
+        project.compile(
+            """
+                import test
+
+                test::Test(
+                    test=["0123456789"],
+                )
+            """,
+            no_dedent=False,
+        )
+
+
+def test_composed(project: Project) -> None:
+    """
+    This simple test creates a simple module containing a type definition.  This type definition
+    is used for a list attribute of the single entity of this module.
+    """
+    module = Module(name="test")
+    module_builder = InmantaModuleBuilder(module)
+
+    typedef = TypeDef(
+        "test",
+        path=[module.name],
+        base_type="string",
+        constraint="std::length(self) >= 10",
+        description="String of minimum 10 characters",
+    )
+
+    typedef1 = TypeDef(
+        "test1",
+        path=[module.name],
+        base_type=typedef,
+        constraint="std::length(self) <= 10",
+        description="String of maximum 10 characters",
+    )
+
+    entity = Entity(
+        "Test",
+        path=[module.name],
+        fields=[
+            Attribute(
+                name="test",
+                inmanta_type=typedef1,
+                description="This is a test attribute",
+            ),
+        ],
+        description="This is a test entity",
+    )
+
+    implement = Implement(
+        path=[module.name],
+        implementation=Implementation(
+            name="none",
+            path=["std"],
+            entity=entity,
+            content="",
+        ),
+        entity=entity,
+    )
+
+    module_builder.add_module_element(typedef)
+    module_builder.add_module_element(typedef1)
+    module_builder.add_module_element(entity)
+    module_builder.add_module_element(implement)
+
+    module_builder.generate_module(Path(project._test_project_dir) / "libs")
+
+    project.compile(
+        """
+            import test
+
+            test::Test(
+                test="0123456789",
+            )
+        """,
+        no_dedent=False,
+    )
+
+    # A string shorter than 10 characters should fail
+    with pytest.raises(inmanta.ast.AttributeException):
+        project.compile(
+            """
+                import test
+
+                test::Test(
+                    test="012345678",
+                )
+            """,
+            no_dedent=False,
+        )
+
+    # A string longer than 10 characters should fail
+    with pytest.raises(inmanta.ast.AttributeException):
+        project.compile(
+            """
+                import test
+
+                test::Test(
+                    test="01234567890",
+                )
+            """,
+            no_dedent=False,
+        )

--- a/tests/test_typedefs.py
+++ b/tests/test_typedefs.py
@@ -23,12 +23,13 @@ import pytest
 from pytest_inmanta.plugin import Project
 
 from inmanta_module_factory.builder import InmantaModuleBuilder
-from inmanta_module_factory.inmanta.attribute import Attribute, InmantaPrimitiveList
+from inmanta_module_factory.inmanta.attribute import Attribute
 from inmanta_module_factory.inmanta.entity import Entity
 from inmanta_module_factory.inmanta.implement import Implement
 from inmanta_module_factory.inmanta.implementation import Implementation
 from inmanta_module_factory.inmanta.module import Module
 from inmanta_module_factory.inmanta.typedef import TypeDef
+from inmanta_module_factory.inmanta.types import InmantaListType, InmantaStringType
 
 
 def test_simple(project: Project) -> None:
@@ -42,7 +43,7 @@ def test_simple(project: Project) -> None:
     typedef = TypeDef(
         "test",
         path=[module.name],
-        base_type="string",
+        base_type=InmantaStringType,
         constraint="std::length(self) > 10",
         description="String of minimum 10 characters",
     )
@@ -113,7 +114,7 @@ def test_list(project: Project) -> None:
     typedef = TypeDef(
         "test",
         path=[module.name],
-        base_type="string",
+        base_type=InmantaStringType,
         constraint="std::length(self) > 10",
         description="String of minimum 10 characters",
     )
@@ -124,7 +125,7 @@ def test_list(project: Project) -> None:
         fields=[
             Attribute(
                 name="test",
-                inmanta_type=InmantaPrimitiveList(typedef),
+                inmanta_type=InmantaListType(typedef),
                 description="This is a test attribute",
             ),
         ],
@@ -185,7 +186,7 @@ def test_composed(project: Project) -> None:
     typedef = TypeDef(
         "test",
         path=[module.name, "types"],
-        base_type="string",
+        base_type=InmantaStringType,
         constraint="std::length(self) >= 10",
         description="String of minimum 10 characters",
     )

--- a/tests/test_typedefs.py
+++ b/tests/test_typedefs.py
@@ -175,8 +175,9 @@ def test_list(project: Project) -> None:
 
 def test_composed(project: Project) -> None:
     """
-    This simple test creates a simple module containing a type definition.  This type definition
-    is used for a list attribute of the single entity of this module.
+    This simple test creates a more complex module containing a few type definitions.
+    One base typedef is defined in a different file, and two different typedefs are defined
+    by adding constraints on this one.
     """
     module = Module(name="test")
     module_builder = InmantaModuleBuilder(module)

--- a/tests/test_typedefs.py
+++ b/tests/test_typedefs.py
@@ -16,10 +16,10 @@
     Contact: code@inmanta.com
     Author: Inmanta
 """
-import pytest
-import inmanta
 from pathlib import Path
 
+import inmanta
+import pytest
 from pytest_inmanta.plugin import Project
 
 from inmanta_module_factory.builder import InmantaModuleBuilder
@@ -99,7 +99,7 @@ def test_simple(project: Project) -> None:
                 )
             """,
             no_dedent=False,
-    )
+        )
 
 
 def test_list(project: Project) -> None:


### PR DESCRIPTION
# Description

Added support for typedefs.  Typedefs will be located at the top of the generated file.

closes #109 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
