### PR TITLE
Update default EULA header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v 2.4.0 (?)
 Changes in this release:
+ - Update default Inmanta EULA header
  - Enhance module v2 generation support.
 
 # v 2.3.0 (2022-07-18)

--- a/src/inmanta_module_factory/helpers/const.py
+++ b/src/inmanta_module_factory/helpers/const.py
@@ -49,8 +49,8 @@ EULA_COPYRIGHT_HEADER_TMPL = '''
 """
     :copyright: %(copyright)s
     :contact: %(contact)s
-    :author: %(author)s
     :license: Inmanta EULA
+    :author: %(author)s
 """
 '''.strip(
     "\n"


### PR DESCRIPTION
# Description

The inmanta module template comes with this regex to check whether a header is valid: https://github.com/inmanta/inmanta-module-template/blob/5a1835c1cde9704cc3053facbb3dd72bbc595535/%7B%7Bcookiecutter.module_name%7Cslugify%7D%7D/setup.cfg#L45.

This header didn't work for that regex, so we update the header here.  (Easier than overwriting the regex)

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
