### PR TITLE
Issue/fix self destroying library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # v 2.5.0 (?)
 Changes in this release:
 
+# v 2.4.1 (?)
+Changes in this release:
+ - Fix self-destructing library when running the generator from a module that has its virtual environment in its folder.
+
 # v 2.4.0 (2022-12-05)
 Changes in this release:
  - Update default Inmanta EULA header

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 # v 2.5.0 (?)
 Changes in this release:
-
-# v 2.4.1 (?)
-Changes in this release:
  - Fix self-destructing library when running the generator from a module that has its virtual environment in its folder.
 
 # v 2.4.0 (2022-12-05)

--- a/src/inmanta_module_factory/builder.py
+++ b/src/inmanta_module_factory/builder.py
@@ -329,7 +329,11 @@ class InmantaModuleBuilder:
 
         module_path = Path(existing_module.path)
         copyright_header_template = utils.copyright_header_from_module(existing_module)
-        utils.remove_watermarked_files(module_path)
+        for module_inner_folder in ["model", "plugins", "inmanta_plugins", "files", "templates", "tests"]:
+            path = module_path / module_inner_folder
+            if not path.exists():
+                continue
+            utils.remove_watermarked_files(path)
 
         LOGGER.debug(f"Module generation: {existing_module.GENERATION.name}")
         if isinstance(existing_module, inmanta.module.ModuleV2):

--- a/src/inmanta_module_factory/builder.py
+++ b/src/inmanta_module_factory/builder.py
@@ -329,11 +329,6 @@ class InmantaModuleBuilder:
 
         module_path = Path(existing_module.path)
         copyright_header_template = utils.copyright_header_from_module(existing_module)
-        for module_inner_folder in ["model", "plugins", "inmanta_plugins", "files", "templates", "tests"]:
-            path = module_path / module_inner_folder
-            if not path.exists():
-                continue
-            utils.remove_watermarked_files(path)
 
         LOGGER.debug(f"Module generation: {existing_module.GENERATION.name}")
         if isinstance(existing_module, inmanta.module.ModuleV2):
@@ -343,6 +338,13 @@ class InmantaModuleBuilder:
 
         plugins_folder = Path(existing_module.get_plugin_dir() or "")
         LOGGER.debug(f"Module's plugins folder: {plugins_folder}")
+
+        for module_inner_folder in [
+            module_path / "model",
+            plugins_folder,
+            module_path / "tests",
+        ]:
+            utils.remove_watermarked_files(module_inner_folder)
 
         self.generate_plugin_file(plugins_folder, False, copyright_header_template)
         self.generate_model_test(module_path / "tests", False, copyright_header_template)

--- a/src/inmanta_module_factory/helpers/const.py
+++ b/src/inmanta_module_factory/helpers/const.py
@@ -61,7 +61,7 @@ EULA_COPYRIGHT_HEADER_TMPL = '''
 INMANTA_RESERVED_KEYWORDS = keyworldlist
 
 
-GENERATED_FILE_MARKER = "IMF-GENERATED-FILE"
+GENERATED_FILE_MARKER = "-".join(["IMF", "GENERATED", "FILE"])
 GENERATED_FILE_FOOTER = f"""
 # This file has been generated using inmanta-module-factory=={__version__}
 # <{GENERATED_FILE_MARKER}/>


### PR DESCRIPTION
# Description

I was seeing a strange error in a ci where I was running code generation on a module, and where some files from the library would disappear... I found out why

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
