### PR TITLE
Issue/491 escape more reserved words

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v 2.5.0 (?)
 Changes in this release:
  - Fix self-destructing library when running the generator from a module that has its virtual environment in its folder.
+ - Extend the list of inmanta reserved keywords with the primitive types (#18).
 
 # v 2.4.0 (2022-12-05)
 Changes in this release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # v 2.5.0 (?)
 Changes in this release:
  - Fix self-destructing library when running the generator from a module that has its virtual environment in its folder.
- - Extend the list of inmanta reserved keywords with the primitive types (#18).
+ - Extend the list of inmanta reserved keywords with the primitive types (#491).
 
 # v 2.4.0 (2022-12-05)
 Changes in this release:

--- a/src/inmanta_module_factory/helpers/const.py
+++ b/src/inmanta_module_factory/helpers/const.py
@@ -16,8 +16,8 @@
     Contact: code@inmanta.com
     Author: Inmanta
 """
-import inmanta.parser.plyInmantaLex
 import inmanta.ast.type
+import inmanta.parser.plyInmantaLex
 
 from inmanta_module_factory import __version__
 

--- a/src/inmanta_module_factory/helpers/const.py
+++ b/src/inmanta_module_factory/helpers/const.py
@@ -16,7 +16,8 @@
     Contact: code@inmanta.com
     Author: Inmanta
 """
-from inmanta.parser.plyInmantaLex import keyworldlist
+import inmanta.parser.plyInmantaLex
+import inmanta.ast.type
 
 from inmanta_module_factory import __version__
 
@@ -58,7 +59,7 @@ EULA_COPYRIGHT_HEADER_TMPL = '''
     "\n"
 )
 
-INMANTA_RESERVED_KEYWORDS = keyworldlist
+INMANTA_RESERVED_KEYWORDS = inmanta.parser.plyInmantaLex.keyworldlist + list(inmanta.ast.type.TYPES.keys())
 
 
 GENERATED_FILE_MARKER = "-".join(["IMF", "GENERATED", "FILE"])


### PR DESCRIPTION
# Description

Update the list of reserved keywords to add the list of primitive types.

closes #491 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
