### PR TITLE
dropped build dep dependency

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,3 +1,2 @@
-build==0.10.0
 inmanta-dev-dependencies[module]==2.82.0
 types-PyYAML==6.0.12.11


### PR DESCRIPTION
Looks like I added this in #453 but I believe that was a mistake: it wasn't a dev dependency before and it doesn't seem to be used anywhere except for the build pipeline.